### PR TITLE
add minimum distance to trigger close-bubble

### DIFF
--- a/FloatingBubbleView/src/main/java/com/torrydo/floatingbubbleview/service/expandable/BubbleBuilder.kt
+++ b/FloatingBubbleView/src/main/java/com/torrydo/floatingbubbleview/service/expandable/BubbleBuilder.kt
@@ -38,6 +38,8 @@ class BubbleBuilder(
 
     internal var distanceToClosePx = 200
 
+    internal var distanceToTriggerCloseButtonPx = 0
+
     internal var closeBubbleBottomPaddingPx = 80
 
     internal var listener: FloatingBubbleListener? = null
@@ -99,6 +101,22 @@ class BubbleBuilder(
      * */
     fun distanceToClose(dp: Int): BubbleBuilder {
         this.distanceToClosePx = dp.toPx()
+        return this
+    }
+
+    /**
+     * @param dp minimum distance bubble needs to be moved to show close-bubble
+     * */
+    fun distanceToTriggerCloseButton(dp: Int): BubbleBuilder {
+        this.distanceToTriggerCloseButtonPx = dp.toPx()
+        return this
+    }
+
+    /**
+     * @param px minimum distance bubble needs to be moved to show close-bubble
+     * */
+    fun distanceToTriggerCloseButtonPx(px: Int): BubbleBuilder {
+        this.distanceToTriggerCloseButtonPx = px
         return this
     }
 

--- a/FloatingBubbleView/src/main/java/com/torrydo/floatingbubbleview/service/expandable/ExpandableBubbleService.kt
+++ b/FloatingBubbleView/src/main/java/com/torrydo/floatingbubbleview/service/expandable/ExpandableBubbleService.kt
@@ -11,6 +11,8 @@ import com.torrydo.floatingbubbleview.bubble.FloatingBubble
 import com.torrydo.floatingbubbleview.bubble.FloatingCloseBubble
 import com.torrydo.floatingbubbleview.service.FloatingBubbleService
 import com.torrydo.floatingbubbleview.sez
+import kotlin.math.pow
+import kotlin.math.sqrt
 
 abstract class ExpandableBubbleService : FloatingBubbleService() {
 
@@ -21,6 +23,10 @@ abstract class ExpandableBubbleService : FloatingBubbleService() {
     // 1: bubble
     // 2: expanded-bubble
     private var state = 0
+
+    var firstX: Float = 0f
+    var firstY: Float = 0f
+    var distanceToTriggerCloseButton: Int = 0
 
     var bubble: FloatingBubble? = null
         private set
@@ -87,6 +93,10 @@ abstract class ExpandableBubbleService : FloatingBubbleService() {
             // setup bottom-background
             if (bubbleBuilder.isBottomBackgroundEnabled) {
                 bottomBackground = FloatingBottomBackground(context)
+            }
+
+            if(bubbleBuilder.distanceToTriggerCloseButtonPx != 0){
+                distanceToTriggerCloseButton = bubbleBuilder.distanceToTriggerCloseButtonPx
             }
 
         }
@@ -209,6 +219,8 @@ abstract class ExpandableBubbleService : FloatingBubbleService() {
 
         override fun onFingerDown(x: Float, y: Float) {
             mBubble.safeCancelAnimation()
+            firstX = x
+            firstY = y
         }
 
         override fun onFingerMove(x: Float, y: Float) {
@@ -227,7 +239,9 @@ abstract class ExpandableBubbleService : FloatingBubbleService() {
                     }
                 }
             }
-            if (isCloseBubbleEnabled && isCloseBubbleVisible.not()) {
+            if (isCloseBubbleEnabled && isCloseBubbleVisible.not() && sqrt(
+                    (x - firstX).toDouble().pow(2) + (y - firstY).pow(2)
+                ) > distanceToTriggerCloseButton) {
                 tryShowCloseBubbleAndBackground()
                 isCloseBubbleVisible = true
             }


### PR DESCRIPTION
It partially solves issue #50 by adding the ability to set a minimum distance that the bubble needs to be moved to trigger displaying close-bubble. It doesn't solve it fully because it's still possible to quickly flick the bubble a longer distance and pull the finger up and the close button will continue showing.