### PR TITLE
Feature set animation before expand show

### DIFF
--- a/FloatingBubbleView/src/main/java/com/torrydo/floatingbubbleview/bubble/FloatingBubble.kt
+++ b/FloatingBubbleView/src/main/java/com/torrydo/floatingbubbleview/bubble/FloatingBubble.kt
@@ -22,6 +22,8 @@ class FloatingBubble(
     private val forceDragging: Boolean = false,
 //    private val ignoreSwipeGesture: Boolean = true,
     containCompose: Boolean,
+    val animateBeforeExpandViewShow : Boolean = false,
+    val locationBeforeExpand : Point = Point(0,0),
     private val listener: FloatingBubbleListener? = null,
     onDispatchKeyEvent: ((KeyEvent) -> Boolean?)? = null
 ) : Bubble(
@@ -141,7 +143,12 @@ class FloatingBubble(
     /**
      * pass close bubble point
      * */
-    fun animateTo(x: Float, y: Float, stiffness: Float = SpringForce.STIFFNESS_MEDIUM) {
+    fun animateTo(
+        x: Float,
+        y: Float,
+        stiffness: Float = SpringForce.STIFFNESS_MEDIUM,
+        onEnd: (() -> Unit)? = null
+    ) {
         AnimHelper.animateSpringPath(
             startX = newPoint.x.toFloat(),
             startY = newPoint.y.toFloat(),
@@ -154,6 +161,11 @@ class FloatingBubble(
 
 //                    builder.listener?.onMove(x.toFloat(), y.toFloat()) // don't call this line, it'll spam multiple MotionEvent.OnActionMove
                     update()
+                }
+
+                override fun onEnd() {
+                    onEnd?.invoke()
+                    super.onEnd()
                 }
             },
             stiffness = stiffness,

--- a/FloatingBubbleView/src/main/java/com/torrydo/floatingbubbleview/service/expandable/BubbleBuilder.kt
+++ b/FloatingBubbleView/src/main/java/com/torrydo/floatingbubbleview/service/expandable/BubbleBuilder.kt
@@ -46,6 +46,8 @@ class BubbleBuilder(
     internal var forceDragging: Boolean = true
     internal var isBubbleDraggable: Boolean = true
 
+    internal var isAnimatedBeforeExpand : Boolean = false
+    internal var expandPoint : Point = Point(0,0)
     fun defaultLayoutParams(): WindowManager.LayoutParams {
         return WindowManager.LayoutParams().apply {
             flags = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
@@ -209,6 +211,23 @@ class BubbleBuilder(
     fun startLocationPx(x: Int, y: Int): BubbleBuilder {
         startPoint.x = x
         startPoint.y = y
+        return this
+    }
+
+    fun animateBeforeExpand(animated:Boolean) : BubbleBuilder {
+        isAnimatedBeforeExpand = animated
+        return this
+    }
+
+    fun pointOfShowExpandViewLocationPx(x: Int, y: Int) : BubbleBuilder {
+        expandPoint.x = x
+        expandPoint.y = y
+        return this
+    }
+
+    fun pointOfShowExpandViewLocation(x: Int, y: Int) : BubbleBuilder {
+        expandPoint.x = x.toPx()
+        expandPoint.y = y.toPx()
         return this
     }
 

--- a/FloatingBubbleView/src/main/java/com/torrydo/floatingbubbleview/service/expandable/BubbleBuilder.kt
+++ b/FloatingBubbleView/src/main/java/com/torrydo/floatingbubbleview/service/expandable/BubbleBuilder.kt
@@ -47,7 +47,7 @@ class BubbleBuilder(
     internal var isBubbleDraggable: Boolean = true
 
     internal var isAnimatedBeforeExpand : Boolean = false
-    internal var expandPoint : Point = Point(0,0)
+    internal var expandViewInitialPoint : Point = Point(0,0)
     fun defaultLayoutParams(): WindowManager.LayoutParams {
         return WindowManager.LayoutParams().apply {
             flags = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
@@ -220,14 +220,14 @@ class BubbleBuilder(
     }
 
     fun pointOfShowExpandViewLocationPx(x: Int, y: Int) : BubbleBuilder {
-        expandPoint.x = x
-        expandPoint.y = y
+        expandViewInitialPoint.x = x
+        expandViewInitialPoint.y = y
         return this
     }
 
     fun pointOfShowExpandViewLocation(x: Int, y: Int) : BubbleBuilder {
-        expandPoint.x = x.toPx()
-        expandPoint.y = y.toPx()
+        expandViewInitialPoint.x = x.toPx()
+        expandViewInitialPoint.y = y.toPx()
         return this
     }
 

--- a/FloatingBubbleView/src/main/java/com/torrydo/floatingbubbleview/service/expandable/ExpandableBubbleService.kt
+++ b/FloatingBubbleView/src/main/java/com/torrydo/floatingbubbleview/service/expandable/ExpandableBubbleService.kt
@@ -50,7 +50,7 @@ abstract class ExpandableBubbleService : FloatingBubbleService() {
                     containCompose = false,
                     listener = bubbleBuilder.listener,
                     animateBeforeExpandViewShow = bubbleBuilder.isAnimatedBeforeExpand,
-                    locationBeforeExpand = bubbleBuilder.expandPoint
+                    locationBeforeExpand = bubbleBuilder.expandViewInitialPoint
                 )
                 bubble!!.rootGroup.addView(bubbleBuilder.bubbleView)
             } else {
@@ -60,7 +60,7 @@ abstract class ExpandableBubbleService : FloatingBubbleService() {
                     containCompose = true,
                     listener = bubbleBuilder.listener,
                     animateBeforeExpandViewShow = bubbleBuilder.isAnimatedBeforeExpand,
-                    locationBeforeExpand = bubbleBuilder.expandPoint
+                    locationBeforeExpand = bubbleBuilder.expandViewInitialPoint
                 )
                 bubble!!.rootGroup.addView(bubbleBuilder.bubbleCompose)
             }

--- a/app/src/main/java/com/torrydo/testfloatingbubble/MyServiceKt.kt
+++ b/app/src/main/java/com/torrydo/testfloatingbubble/MyServiceKt.kt
@@ -1,5 +1,6 @@
 package com.torrydo.testfloatingbubble
 
+import android.graphics.Point
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
@@ -27,6 +28,7 @@ class MyServiceKt : ExpandableBubbleService() {
     }
 
     override fun configBubble(): BubbleBuilder? {
+        val showExpandViewPoint = calculateExpandViewStartPoint()
         val imgView = ViewHelper.fromDrawable(this, R.drawable.ic_rounded_blue_diamond, 60, 60)
 
         imgView.setOnClickListener {
@@ -85,6 +87,8 @@ class MyServiceKt : ExpandableBubbleService() {
 
                 override fun onFingerDown(x: Float, y: Float) {} // ..., when finger tap the bubble
             })
+            .animateBeforeExpand(true)
+            .pointOfShowExpandViewLocationPx(showExpandViewPoint.x,0)
 
     }
 
@@ -98,10 +102,10 @@ class MyServiceKt : ExpandableBubbleService() {
         return ExpandedBubbleBuilder(this)
 //            .expandedView(expandedView)
             .expandedCompose {
-                TestComposeView(popBack = {minimize()})
+                TestComposeView(popBack = { minimize() })
             }
             .onDispatchKeyEvent {
-                if(it.keyCode == KeyEvent.KEYCODE_BACK){
+                if (it.keyCode == KeyEvent.KEYCODE_BACK) {
                     minimize()
                 }
                 null
@@ -113,4 +117,12 @@ class MyServiceKt : ExpandableBubbleService() {
             .enableAnimateToEdge(true)
             .dimAmount(0.5f)
     }
+}
+
+private fun MyServiceKt.calculateExpandViewStartPoint(): Point {
+    val metrics = resources.displayMetrics
+    val bubbleViewWidthPx = (60 * metrics.density).toInt()
+    val startPositionWidth = (metrics.widthPixels / 2) - bubbleViewWidthPx
+    val startPositionHeight = metrics.heightPixels
+    return Point(startPositionWidth,startPositionHeight)
 }


### PR DESCRIPTION
**Hi,**

In our case, we require the bubble view to move to a specific location before the expand view is shown. I have added some properties that users can set, and when the `expand()` function is called, the bubble view animates to the specified location before showing the expand view.

Set `isAnimatedBeforeExpand` to true: when the `expand()` method is called, the bubble view animates to the `expandViewInitialPoint`.
> internal var isAnimatedBeforeExpand : Boolean = false
> internal var expandViewInitialPoint : Point = Point(0,0)

Also, I have added a new nullable lambda to the `animateTo()` function to be called when the animation is finished.

`fun animateTo(
        x: Float,
        y: Float,
        stiffness: Float = SpringForce.STIFFNESS_MEDIUM,
        onEnd: (() -> Unit)? = null
    )`

**Best regards.**
/assign_reviewer @TorryDo 